### PR TITLE
delimit by comma rather than semicolon

### DIFF
--- a/js/dataTables.CSV.js
+++ b/js/dataTables.CSV.js
@@ -68,7 +68,7 @@ $.fn.dataTableExt.aoFeatures.push({
 			}
 
 			if (rowParts.length > 0) {
-				contentParts.push(rowParts.join(";"));
+				contentParts.push(rowParts.join(","));
 			}
 
 			// Rows
@@ -93,7 +93,7 @@ $.fn.dataTableExt.aoFeatures.push({
 						}
 					}
 				}
-				contentParts.push(rowParts.join(";"));
+				contentParts.push(rowParts.join(","));
 			}
 
 			btn.setAttribute("href", "data:text/csv;charset=utf-8," + encodeURIComponent(contentParts.join("\n")));


### PR DESCRIPTION
Great work with this, just thought I'd throw a quick change up to delimit by comma rather than semicolon since csv readers don't usually handle semicolons by default.
